### PR TITLE
Fixed a bug undefined values in Yoyo.on()

### DIFF
--- a/src/assets/js/yoyo.js
+++ b/src/assets/js/yoyo.js
@@ -27,7 +27,11 @@
 				YoyoEngine.on(window, name, (event) => {
 					delete event.detail.elt
 					callback(
-						event.detail.length > 1 ? event.detail : event.detail[0]
+						(
+							(Array.isArray(event.detail) && event.detail.length > 1)
+							|| (event.detail === Object(event.detail))
+						)
+							? event.detail : event.detail[0]
 					)
 				})
 			},


### PR DESCRIPTION
Fixed a bug undefined values in Yoyo.on() when passing key-value arrays to dispatchBrowserEvent