### PR TITLE
Add Yoyo.dispatch() and Yoyo.dispatchTo() JS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,6 +911,34 @@ Yoyo.on('productAddedToCart', id => {
 
 With this feature you can control toasters, alerts, modals, etc. directly from a component action on the server by emitting the event and listening for it on the browser.
 
+### Dispatching Events From JavaScript
+
+You can also trigger component events directly from your custom JavaScript using the `Yoyo.dispatch()` method. This is useful when you need to interact with other JavaScript libraries or custom browser APIs.
+
+```js
+// Dispatch an event to all Yoyo components listening for it
+Yoyo.dispatch('post-created');
+
+// You can also pass named parameters to the event listener
+Yoyo.dispatch('post-created', { postId: 2 });
+
+// Dispatch an event to a specific component by name
+Yoyo.dispatchTo('dashboard', 'post-created', { postId: 2 });
+```
+
+Parameters are passed as named arguments that match the listener method's parameter names:
+
+```php
+protected $listeners = [
+    'post-created' => 'handlePostCreated',
+];
+
+public function handlePostCreated($postId)
+{
+    // $postId will be 2
+}
+```
+
 ### Dispatching Browser Events
 
 In addition to allowing components to communicate with each other, you can also send browser window events directly from a component method or template:

--- a/src/assets/js/yoyo.js
+++ b/src/assets/js/yoyo.js
@@ -29,6 +29,17 @@
 					callback(event.detail)
 				})
 			},
+			dispatch(eventName, params = null) {
+				this.processEmitEvents(document.body, [
+					{ event: eventName, params: params }
+				])
+			},
+			dispatchTo(componentName, eventName, params = null) {
+				if (!/^[a-zA-Z0-9._-]+$/.test(componentName)) return
+				this.processEmitEvents(document.body, [
+					{ event: eventName, params: params, component: componentName }
+				])
+			},
 			createNonExistentIdTarget(targetId) {
 				// Dynamically create non-existent target IDs by appending them to document body
 				if (
@@ -422,6 +433,8 @@
 			const componentName = event.component || null
 			const propagation = event.propagation || null
 			let elements
+
+			if (!component && (propagation === 'self' || selector)) return
 
 			// emit
 			if (!selector && !componentName) {

--- a/src/yoyo/ClassHelpers.php
+++ b/src/yoyo/ClassHelpers.php
@@ -15,6 +15,8 @@ class ClassHelpers
 
     private static array $traitCache = [];
 
+    private static array $paramTypeCache = [];
+
     public static function getDefaultPublicVars($instance, $baseClass = null)
     {
         $className = get_class($instance);
@@ -198,6 +200,13 @@ class ClassHelpers
      */
     public static function getMethodParametersWithTypes($class, $method)
     {
+        $className = is_object($class) ? get_class($class) : $class;
+        $cacheKey = $className . ':' . $method;
+
+        if (isset(static::$paramTypeCache[$cacheKey])) {
+            return static::$paramTypeCache[$cacheKey];
+        }
+
         $typed = [];    // Parameters with class type hints (for DI)
         $regular = [];  // Parameters without type hints or with builtin types
 
@@ -221,7 +230,7 @@ class ClassHelpers
             }
         }
 
-        return [
+        return static::$paramTypeCache[$cacheKey] = [
             'typed' => $typed,
             'regular' => $regular,
         ];
@@ -233,5 +242,6 @@ class ClassHelpers
         static::$defaultVarCache = [];
         static::$methodCache = [];
         static::$traitCache = [];
+        static::$paramTypeCache = [];
     }
 }

--- a/src/yoyo/ComponentManager.php
+++ b/src/yoyo/ComponentManager.php
@@ -105,6 +105,13 @@ class ComponentManager
 
         $eventParams = $this->request->get('eventParams', []);
 
+        // Guard: Request::get() returns raw string when test_json decodes to falsy value ([], {})
+        // TODO: Root cause is test_json falsy check in Request::get() — track as separate fix
+        if (is_string($eventParams)) {
+            $decoded = json_decode($eventParams, true, 32);
+            $eventParams = is_array($decoded) ? $decoded : [];
+        }
+
         $this->component->spinning($this->spinning)->boot($variables, $attributes);
 
         $hookStack = [
@@ -157,60 +164,77 @@ class ComponentManager
         if (! in_array($action, ['render', 'refresh'])) {
             $parameters = $isEventListenerAction ? $eventParams : $this->parseActionArguments();
 
-            // Get parameter information with types
-            $paramInfo = ClassHelpers::getMethodParametersWithTypes($this->component, $action);
-            $regularParams = $paramInfo['regular'];
-            $typedParams = $paramInfo['typed'];
+            // Empty params must fall through to existing no-params handling in the else branch
+            if ($isEventListenerAction && is_array($parameters) && ! empty($parameters) && array_values($parameters) !== $parameters) {
+                // Associative array from JS dispatch — validate required params then pass as named args
+                $paramInfo = ClassHelpers::getMethodParametersWithTypes($this->component, $action);
+                $regularParams = $paramInfo['regular'];
 
-            // Extract just the names of regular parameters for backwards compatibility
-            $parameterNames = array_column($regularParams, 'name');
-
-            // Check if the last regular parameter is variadic
-            $hasVariadic = ! empty($regularParams) && end($regularParams)['variadic'];
-
-            // Handle variadic parameters
-            if ($hasVariadic && count($parameterNames) > 0) {
-                $regularParamCount = count($parameterNames) - 1; // Exclude the variadic parameter
-
-                if (count($parameters) >= $regularParamCount) {
-                    // Split parameters into regular and variadic
-                    $regularParamValues = array_slice($parameters, 0, $regularParamCount);
-                    $variadicParamValues = array_slice($parameters, $regularParamCount);
-
-                    // Create args array with named regular parameters and indexed variadic parameters
-                    $args = [];
-                    for ($i = 0; $i < $regularParamCount; $i++) {
-                        $args[$parameterNames[$i]] = $regularParamValues[$i] ?? null;
-                    }
-
-                    // Add variadic parameters as indexed values (not named)
-                    foreach ($variadicParamValues as $value) {
-                        $args[] = $value;
-                    }
-                } else {
-                    throw new \InvalidArgumentException("Too few parameters passed to [{$this->name}::{$action}]");
-                }
-            } else {
-                // Check if all regular parameters are optional
-                $requiredCount = 0;
                 foreach ($regularParams as $param) {
-                    if (! $param['optional']) {
-                        $requiredCount++;
+                    if (! $param['optional'] && ! $param['variadic'] && ! isset($parameters[$param['name']])) {
+                        throw new \InvalidArgumentException(
+                            "Missing required parameter [{$param['name']}] for [{$this->name}::{$action}]"
+                        );
                     }
                 }
 
-                // Only validate regular parameters (not typed/DI parameters)
-                if (count($parameters) >= $requiredCount && count($parameters) <= count($parameterNames)) {
-                    // Parameters count is valid (between required and total)
-                    $args = [];
-                    for ($i = 0; $i < count($parameterNames); $i++) {
-                        $args[$parameterNames[$i]] = $parameters[$i] ?? null;
+                $args = $parameters;
+            } else {
+                // Get parameter information with types
+                $paramInfo = ClassHelpers::getMethodParametersWithTypes($this->component, $action);
+                $regularParams = $paramInfo['regular'];
+                $typedParams = $paramInfo['typed'];
+
+                // Extract just the names of regular parameters for backwards compatibility
+                $parameterNames = array_column($regularParams, 'name');
+
+                // Check if the last regular parameter is variadic
+                $hasVariadic = ! empty($regularParams) && end($regularParams)['variadic'];
+
+                // Handle variadic parameters
+                if ($hasVariadic && count($parameterNames) > 0) {
+                    $regularParamCount = count($parameterNames) - 1; // Exclude the variadic parameter
+
+                    if (count($parameters) >= $regularParamCount) {
+                        // Split parameters into regular and variadic
+                        $regularParamValues = array_slice($parameters, 0, $regularParamCount);
+                        $variadicParamValues = array_slice($parameters, $regularParamCount);
+
+                        // Create args array with named regular parameters and indexed variadic parameters
+                        $args = [];
+                        for ($i = 0; $i < $regularParamCount; $i++) {
+                            $args[$parameterNames[$i]] = $regularParamValues[$i] ?? null;
+                        }
+
+                        // Add variadic parameters as indexed values (not named)
+                        foreach ($variadicParamValues as $value) {
+                            $args[] = $value;
+                        }
+                    } else {
+                        throw new \InvalidArgumentException("Too few parameters passed to [{$this->name}::{$action}]");
                     }
-                } elseif (empty($parameterNames) && empty($parameters)) {
-                    // Method has only typed parameters (or no parameters at all)
-                    $args = [];
                 } else {
-                    throw new \InvalidArgumentException("Incorrect number of parameters passed to [{$this->name}::{$action}]");
+                    // Check if all regular parameters are optional
+                    $requiredCount = 0;
+                    foreach ($regularParams as $param) {
+                        if (! $param['optional']) {
+                            $requiredCount++;
+                        }
+                    }
+
+                    // Only validate regular parameters (not typed/DI parameters)
+                    if (count($parameters) >= $requiredCount && count($parameters) <= count($parameterNames)) {
+                        // Parameters count is valid (between required and total)
+                        $args = [];
+                        for ($i = 0; $i < count($parameterNames); $i++) {
+                            $args[$parameterNames[$i]] = $parameters[$i] ?? null;
+                        }
+                    } elseif (empty($parameterNames) && empty($parameters)) {
+                        // Method has only typed parameters (or no parameters at all)
+                        $args = [];
+                    } else {
+                        throw new \InvalidArgumentException("Incorrect number of parameters passed to [{$this->name}::{$action}]");
+                    }
                 }
             }
 

--- a/tests/Browser/Components/DispatchBystander.php
+++ b/tests/Browser/Components/DispatchBystander.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\Browser\Components;
+
+use Clickfwd\Yoyo\Component;
+
+class DispatchBystander extends Component
+{
+    public $label = 'unchanged';
+
+    protected $props = ['label'];
+}

--- a/tests/Browser/Components/DispatchListener.php
+++ b/tests/Browser/Components/DispatchListener.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Browser\Components;
+
+use Clickfwd\Yoyo\Component;
+
+class DispatchListener extends Component
+{
+    public $message = '';
+
+    protected $listeners = [
+        'post-created' => 'handlePostCreated',
+        'status-changed' => 'handleStatusChanged',
+        'simple-refresh' => 'handleSimpleRefresh',
+    ];
+
+    public function handlePostCreated($postId)
+    {
+        $this->message = "Post created with ID: {$postId}";
+    }
+
+    public function handleStatusChanged($status, $reason = 'none')
+    {
+        $this->message = "Status: {$status}, Reason: {$reason}";
+    }
+
+    public function handleSimpleRefresh()
+    {
+        $this->message = 'Refreshed without params';
+    }
+}

--- a/tests/Browser/DispatchTest.php
+++ b/tests/Browser/DispatchTest.php
@@ -1,0 +1,51 @@
+<?php
+
+require __DIR__.'/bootstrap.php';
+
+it('registers listener events in hx-trigger attribute', function () {
+    $this->visit(BASE_URL.'/dispatch')
+        ->assertSourceHas('yoyo:name="dispatch-listener"')
+        ->assertSourceHas('hx-trigger="refresh,post-created,status-changed,simple-refresh"');
+});
+
+it('dispatches event with single named param', function () {
+    $this->visit(BASE_URL.'/dispatch')
+        ->click('#btn-dispatch')
+        ->assertSeeIn('#message', 'Post created with ID: 42');
+});
+
+it('dispatches event with multiple named params', function () {
+    $this->visit(BASE_URL.'/dispatch')
+        ->click('#btn-dispatch-multi')
+        ->assertSeeIn('#message', 'Status: active, Reason: manual');
+});
+
+it('dispatches targeted event via dispatchTo', function () {
+    $this->visit(BASE_URL.'/dispatch')
+        ->click('#btn-dispatch-to')
+        ->assertSeeIn('#message', 'Post created with ID: 7');
+});
+
+it('dispatches event without params', function () {
+    $this->visit(BASE_URL.'/dispatch')
+        ->click('#btn-dispatch-no-params')
+        ->assertSeeIn('#message', 'Refreshed without params');
+});
+
+it('does not update non-listening bystander component', function () {
+    $this->visit(BASE_URL.'/dispatch')
+        ->assertSeeIn('#bystander', 'unchanged')
+        ->click('#btn-dispatch')
+        ->assertSeeIn('#message', 'Post created with ID: 42')
+        ->assertSeeIn('#bystander', 'unchanged');
+});
+
+it('dispatchTo non-existent component is a silent no-op', function () {
+    $page = $this->visit(BASE_URL.'/dispatch');
+
+    $page->click('#btn-dispatch-nonexistent');
+    $page->wait(1);
+
+    // Listener should still have empty message — component was not updated
+    $page->assertSourceHas('<span id="message"></span>');
+});

--- a/tests/Browser/server/pages/dispatch.php
+++ b/tests/Browser/server/pages/dispatch.php
@@ -1,0 +1,26 @@
+<?php
+
+require __DIR__.'/../layout.php';
+
+ob_start();
+?>
+<div id="dispatch-test">
+    <div data-listener-area>
+        <?php echo Yoyo\yoyo_render('dispatch-listener', [], ['id' => 'dispatch-listener']); ?>
+    </div>
+    <div data-bystander-area>
+        <?php echo Yoyo\yoyo_render('dispatch-bystander', [
+            'label' => 'unchanged',
+        ], ['id' => 'dispatch-bystander']); ?>
+    </div>
+    <div data-buttons>
+        <button id="btn-dispatch" onclick="Yoyo.dispatch('post-created', { postId: 42 })">Dispatch</button>
+        <button id="btn-dispatch-to" onclick="Yoyo.dispatchTo('dispatch-listener', 'post-created', { postId: 7 })">DispatchTo</button>
+        <button id="btn-dispatch-multi" onclick="Yoyo.dispatch('status-changed', { status: 'active', reason: 'manual' })">Multi Params</button>
+        <button id="btn-dispatch-no-params" onclick="Yoyo.dispatch('simple-refresh')">No Params</button>
+        <button id="btn-dispatch-nonexistent" onclick="Yoyo.dispatchTo('nonexistent', 'post-created', { postId: 1 })">Nonexistent</button>
+    </div>
+</div>
+<?php
+
+render_page('Dispatch', ob_get_clean());

--- a/tests/Browser/server/views/dispatch-bystander.php
+++ b/tests/Browser/server/views/dispatch-bystander.php
@@ -1,0 +1,3 @@
+<div id="dispatch-bystander">
+    <span id="bystander"><?php echo $label; ?></span>
+</div>

--- a/tests/Browser/server/views/dispatch-listener.php
+++ b/tests/Browser/server/views/dispatch-listener.php
@@ -1,0 +1,3 @@
+<div id="dispatch-listener">
+    <span id="message"><?php echo $message; ?></span>
+</div>

--- a/tests/Feature/DispatchEventTest.php
+++ b/tests/Feature/DispatchEventTest.php
@@ -1,0 +1,141 @@
+<?php
+
+use Clickfwd\Yoyo\Exceptions\ComponentMethodNotFound;
+use Clickfwd\Yoyo\Services\BrowserEventsService;
+use Clickfwd\Yoyo\Services\Response;
+
+use function Tests\mockYoyoGetRequest;
+use function Tests\resetYoyoRequest;
+use function Tests\yoyo_update;
+use function Tests\yoyo_view;
+
+uses()->group('dispatch');
+
+beforeAll(function () {
+    yoyo_view();
+});
+
+beforeEach(function () {
+    // Reset singletons for clean state (mirrors ComponentLifecycleTest)
+    $ref = new ReflectionClass(BrowserEventsService::class);
+    $prop = $ref->getProperty('instance');
+    $prop->setAccessible(true);
+    $prop->setValue(null, null);
+
+    $ref = new ReflectionClass(Response::class);
+    $prop = $ref->getProperty('instance');
+    $prop->setAccessible(true);
+    $prop->setValue(null, null);
+});
+
+afterEach(function () {
+    resetYoyoRequest();
+});
+
+// =============================================================================
+// JS Dispatch - Associative (named) params: Yoyo.dispatch('event', { key: val })
+// =============================================================================
+
+it('handles JS dispatch with single named parameter', function () {
+    // Simulates: Yoyo.dispatch('post-created', { postId: 42 })
+    mockYoyoGetRequest('http://example.com/', 'dispatch-listener/post-created', '', [
+        'eventParams' => json_encode(['postId' => 42]),
+    ]);
+
+    $output = yoyo_update();
+
+    expect($output)->toContain('Post created with ID: 42');
+});
+
+it('handles JS dispatch with multiple named parameters', function () {
+    // Simulates: Yoyo.dispatch('status-changed', { status: 'active', reason: 'manual' })
+    mockYoyoGetRequest('http://example.com/', 'dispatch-listener/status-changed', '', [
+        'eventParams' => json_encode(['status' => 'active', 'reason' => 'manual']),
+    ]);
+
+    $output = yoyo_update();
+
+    expect($output)->toContain('Status: active, Reason: manual');
+});
+
+it('handles JS dispatch with named params where optional param is omitted', function () {
+    // Simulates: Yoyo.dispatch('status-changed', { status: 'paused' })
+    // 'reason' has a default value of 'none', should use it
+    mockYoyoGetRequest('http://example.com/', 'dispatch-listener/status-changed', '', [
+        'eventParams' => json_encode(['status' => 'paused']),
+    ]);
+
+    $output = yoyo_update();
+
+    expect($output)->toContain('Status: paused, Reason: none');
+});
+
+// =============================================================================
+// JS Dispatch - No params: Yoyo.dispatch('event')
+// =============================================================================
+
+it('handles JS dispatch without parameters', function () {
+    // Simulates: Yoyo.dispatch('simple-refresh') with explicit empty object
+    // Must use stdClass to produce JSON object '{}' matching JS JSON.stringify({})
+    // json_encode([]) produces '[]' which is the server-side emit case — different path
+    mockYoyoGetRequest('http://example.com/', 'dispatch-listener/simple-refresh', '', [
+        'eventParams' => json_encode(new stdClass()),
+    ]);
+
+    $output = yoyo_update();
+
+    expect($output)->toContain('Refreshed without params');
+});
+
+// =============================================================================
+// JS Dispatch - Missing required parameter
+// =============================================================================
+
+it('throws exception when required named parameter is missing', function () {
+    // Simulates: Yoyo.dispatch('status-changed', { reason: 'manual' })
+    // 'status' is required but missing from the payload
+    mockYoyoGetRequest('http://example.com/', 'dispatch-listener/status-changed', '', [
+        'eventParams' => json_encode(['reason' => 'manual']),
+    ]);
+
+    yoyo_update();
+})->throws(\InvalidArgumentException::class);
+
+// =============================================================================
+// Server-side emit - Sequential (positional) params (existing behavior)
+// =============================================================================
+
+it('handles server-side emit with sequential parameters', function () {
+    // Simulates server-side: $this->emit('post-created', 99)
+    // Server emit sends params as numerically indexed array
+    mockYoyoGetRequest('http://example.com/', 'dispatch-listener/post-created', '', [
+        'eventParams' => json_encode([99]),
+    ]);
+
+    $output = yoyo_update();
+
+    expect($output)->toContain('Post created with ID: 99');
+});
+
+it('handles server-side emit with multiple sequential parameters', function () {
+    // Simulates: $this->emit('multi-param', 'My Title', 'My Body', 5)
+    mockYoyoGetRequest('http://example.com/', 'dispatch-listener/multi-param', '', [
+        'eventParams' => json_encode(['My Title', 'My Body', 5]),
+    ]);
+
+    $output = yoyo_update();
+
+    expect($output)->toContain('Title: My Title, Body: My Body, Category: 5');
+});
+
+// =============================================================================
+// Security - only declared listeners can be triggered
+// =============================================================================
+
+it('rejects dispatch to non-listener event name', function () {
+    // Event name 'nonExistentEvent' is not declared in $listeners
+    // Exception fires during listener routing, before eventParams are read
+    mockYoyoGetRequest('http://example.com/', 'dispatch-listener/nonExistentEvent', '', []);
+
+    yoyo_update();
+})->throws(ComponentMethodNotFound::class);

--- a/tests/app/Yoyo/DispatchListener.php
+++ b/tests/app/Yoyo/DispatchListener.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\App\Yoyo;
+
+use Clickfwd\Yoyo\Component;
+
+class DispatchListener extends Component
+{
+    public $message = '';
+
+    public $postId = 0;
+
+    public $status = 'idle';
+
+    protected $listeners = [
+        'post-created' => 'handlePostCreated',
+        'status-changed' => 'handleStatusChanged',
+        'simple-refresh' => 'handleSimpleRefresh',
+        'multi-param' => 'handleMultiParam',
+    ];
+
+    public function handlePostCreated($postId)
+    {
+        $this->postId = $postId;
+        $this->message = "Post created with ID: {$postId}";
+    }
+
+    public function handleStatusChanged($status, $reason = 'none')
+    {
+        $this->status = $status;
+        $this->message = "Status: {$status}, Reason: {$reason}";
+    }
+
+    public function handleSimpleRefresh()
+    {
+        $this->message = 'Refreshed without params';
+    }
+
+    public function handleMultiParam($title, $body, $categoryId)
+    {
+        $this->message = "Title: {$title}, Body: {$body}, Category: {$categoryId}";
+    }
+}

--- a/tests/app/resources/views/yoyo/dispatch-listener.php
+++ b/tests/app/resources/views/yoyo/dispatch-listener.php
@@ -1,0 +1,5 @@
+<div id="dispatch-listener">
+    <span id="message"><?php echo $message; ?></span>
+    <span id="post-id"><?php echo $postId; ?></span>
+    <span id="status"><?php echo $status; ?></span>
+</div>


### PR DESCRIPTION
## Summary

Adds `Yoyo.dispatch()` and `Yoyo.dispatchTo()` methods that allow triggering component events directly from JavaScript, matching Livewire 3's dispatch API signatures. This is an alternative implementation to #35 that reuses the existing `processEmitEvents` pipeline instead of duplicating the dispatch loop.

**Thanks to @mucan54 for the original proposal in #35** — this PR takes the same idea but implements it as thin wrappers (6 lines of JS) around the existing event infrastructure.

### What's included

**JS (src/assets/js/yoyo.js)**
- `Yoyo.dispatch(eventName, params)` — broadcast to all listening components
- `Yoyo.dispatchTo(componentName, eventName, params)` — target a specific component
- `params = null` default to avoid test_json empty-decode bug
- `componentName` regex validation to prevent CSS selector injection
- Null-guard in `triggerServerEmittedEvent` for defensive safety

**PHP (src/yoyo/ComponentManager.php)**
- Named-parameter support: JS object params `{ postId: 2 }` map to listener method arguments by name
- Required-parameter validation: throws `InvalidArgumentException` if a required param is missing
- `is_string` guard for `test_json` empty-params decode bug (defense-in-depth)
- Existing positional (sequential array) parameter mapping unchanged for backward compatibility

**PHP (src/yoyo/ClassHelpers.php)**
- Added static cache to `getMethodParametersWithTypes()` consistent with other ClassHelpers caches

**Tests (15 total: 8 feature + 7 browser)**

Feature tests:
- Named params (single, multiple, optional omitted)
- Empty params (exercises test_json bug fix)
- Missing required param → InvalidArgumentException
- Sequential positional params (backward compat)
- Non-listener event → ComponentMethodNotFound

Browser tests (full JS → HTMX → PHP → re-render E2E):
- Listener registration in hx-trigger attribute
- dispatch() with single and multiple named params
- dispatchTo() targeted delivery
- No-params dispatch
- Bystander component isolation (non-listener unaffected)
- Non-existent target is silent no-op

**README** — "Dispatching Events From JavaScript" documentation section

### Usage

```js
// Dispatch to all listening components
Yoyo.dispatch('post-created', { postId: 2 });

// Dispatch to a specific component
Yoyo.dispatchTo('dashboard', 'post-created', { postId: 2 });
```

```php
protected $listeners = [
    'post-created' => 'handlePostCreated',
];

public function handlePostCreated($postId)
{
    // $postId will be 2
}
```

## Test plan

- [x] All 457 existing tests pass (0 regressions)
- [x] 8 new feature tests pass
- [x] 7 new browser tests pass (Playwright E2E)
- [x] PHP CS Fixer clean on all changed files
- [ ] @mucan54 — Would appreciate your testing and feedback on this alternative approach. The API surface is identical to what you proposed; the difference is in the internal implementation.

Supersedes #35